### PR TITLE
Docker file, undo pinning python and gdal version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,10 @@ RUN apt-get install -y curl grep sed dpkg postgresql-plpython3-10 unzip python3-
     rm tini.deb && \
     apt-get clean
 
-RUN conda install -c conda-forge python=3.6
-RUN conda config --remove channels 'defaults'
+RUN conda install -c conda-forge python
+#RUN conda config --remove channels 'defaults'
 RUN conda install -c conda-forge jupyterlab ncurses pyproj beautifulsoup4 shapely psycopg2 matplotlib basemap
-RUN conda install --channel conda-forge --override-channels "gdal>2.2.4"
+RUN conda install --channel conda-forge gdal
 
 # check that key packages are importable
 RUN python -c 'from osgeo import gdal'


### PR DESCRIPTION
@mbjoseph , i am wondering why you needed to specify version of python and gdal in Dockerfile?

With the version of Dockerfile in #17 , I got runtime error in loading pyproj and gdal, not being able to find .so file, or some symbol not found from binary, similar to what reported here https://github.com/conda-forge/r-sf-feedstock/issues/3 .    I remove the specification of python and gdal from dockerfile, and it seems to be working now.

Would it make sense to undo this specification?